### PR TITLE
Fix "pg_config executable not found" missing dep

### DIFF
--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -12,3 +12,4 @@ synapse_dependencies:
   - libssl-dev
   - libjpeg-dev
   - libxslt1-dev
+  - libpq-dev


### PR DESCRIPTION
When executing this role on a fresh Ubuntu 20.4 LTS Machine, the error
"Error: pg_config executable not found." appears during the task "Make
sure synapse is installed to the VEnv". Therefore, the `libpq-dev`
package needs to be installted[^1].

[^1]: https://stackoverflow.com/questions/11618898/pg-config-executable-not-found#12037133